### PR TITLE
Use license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,13 +7,8 @@
 		"loader-utils": "0.2.x",
 		"source-map": "0.1.x"
 	},
-	"licenses": [
-		{
-			"type": "MIT",
-			"url": "http://www.opensource.org/licenses/mit-license.php"
-		}
-	],
-	"repository": { 
+	"license": "MIT",
+	"repository": {
 		"type": "git",
 		"url" : "https://github.com/webpack/imports-loader.git"
 	}


### PR DESCRIPTION
Array deprecated in `npm@2.10.0`

https://github.com/npm/npm/blob/master/doc/files/package.json.md#license