### PR TITLE
Adds support for importing multiple dependencies as an array

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,18 +13,28 @@ module.exports = function(content, sourceMap) {
 	var postfixes = [];
 	Object.keys(query).forEach(function(name) {
 		var value;
+		var values = [];
 		if(typeof query[name] == "string" && query[name].substr(0, 1) == ">") {
 			value = query[name].substr(1);
 		} else {
 			var mod = name;
 			if(typeof query[name] === "string") {
 				mod = query[name];
+			} else if (Array.isArray(query[name])) {
+				query[name].forEach(function(el) {
+					values.push("require(" + JSON.stringify(el) + ")");
+				})
 			}
 			value = "require(" + JSON.stringify(mod) + ")";
 		}
 		if(name === "this") {
 			imports.push("(function() {");
 			postfixes.unshift("}.call(" + value + "));");
+		} else if (values.length) {
+			imports.push("var " + name + " = [];")
+			values.forEach(function(val) {
+				imports.push(name + ".push(" + val + ");");
+			})
 		} else {
 			imports.push("var " + name + " = " + value + ";");
 		}


### PR DESCRIPTION
Adds support for something like this:

```js
{ loader: 'imports?plugins[]=module1,plugins[]=module2' }
```

As stated in the [loader-utils docs](https://github.com/webpack/loader-utils#methods), this sort of query string can be used to create an array. In my example, the variable `plugins` will be available. It will produce code like this:

```js
/*** IMPORTS FROM imports-loader ***/
var plugins = [];
plugins.push(__webpack_require__(510));
plugins.push(__webpack_require__(600));
```
This is a very specific use case, and only adds complexity. If there's no reason to merge this, I'm fine with maintaining my own fork.