### PR TITLE
Allow setting window values instead of vars

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,13 @@ module.exports = function(content, sourceMap) {
 			imports.push("(function() {");
 			postfixes.unshift("}.call(" + value + "));");
 		} else {
-			imports.push("var " + name + " = " + value + ";");
+			if (name.substring(0, 7) === 'window.') {
+				imports.push(name + " = " + value + ";");
+				postfixes.unshift("delete " + name + ";");
+			} else {
+				imports.push("var " + name + " = " + value + ";");
+			}
+
 		}
 	});
 	var prefix = HEADER + imports.join("\n") + "\n\n";


### PR DESCRIPTION
Proposed fix for #19.

Adds a check if the name begins with "window." and instead of using a `var` declaration it will define a `window` variable and delete it in postfixes.

To test this I shimmed the `node-mathquill` module which references `window.jQuery` instead of just `jQuery` using the following config.

```
{
  test: /mathquill\.js$/,
  include: [/node-mathquill/],
  // Grab the MathQuill export, provide jQuery
  loaders: ['imports?window.jQuery=jquery', 'exports?MathQuill']
},
```

I verified that other var declaration imports worked for my other vendor files as before and I verified that the window.jQuery reference was deleted at the end of that module after exporting.
