### PR TITLE
Support dot notation in variable names

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,9 +30,9 @@ module.exports = function(content, sourceMap) {
 				var expr = (previous.length > 0 ? previous : "var ") + current;
 
 				if(index < names.length-1) {
-					imports.push(expr += " = {};");
+					imports.push(expr + " = {};");
 				} else {
-					imports.push(expr += " = " + value + ";");
+					imports.push(expr + " = " + value + ";");
 				}
 
 				return previous + current + ".";

--- a/index.js
+++ b/index.js
@@ -25,6 +25,18 @@ module.exports = function(content, sourceMap) {
 		if(name === "this") {
 			imports.push("(function() {");
 			postfixes.unshift("}.call(" + value + "));");
+		} else if(name.indexOf(".") !== -1) {
+			name.split(".").reduce(function(previous, current, index, names) {
+				var expr = (previous.length > 0 ? previous : "var ") + current;
+
+				if(index < names.length-1) {
+					imports.push(expr += " = {};");
+				} else {
+					imports.push(expr += " = " + value + ";");
+				}
+
+				return previous + current + ".";
+			}, "");
 		} else {
 			imports.push("var " + name + " = " + value + ";");
 		}

--- a/index.js
+++ b/index.js
@@ -27,10 +27,10 @@ module.exports = function(content, sourceMap) {
 			postfixes.unshift("}.call(" + value + "));");
 		} else if(name.indexOf(".") !== -1) {
 			name.split(".").reduce(function(previous, current, index, names) {
-				var expr = (previous.length > 0 ? previous : "var ") + current;
+				var expr = previous + current;
 
-				if(expr === "var window") {
-					imports.push("window = (window || {});");
+				if(previous.length === 0) {
+					imports.push("var " + expr + " = (" + current + " || {});");
 				} else if(index < names.length-1) {
 					imports.push(expr + " = {};");
 				} else {

--- a/index.js
+++ b/index.js
@@ -29,7 +29,9 @@ module.exports = function(content, sourceMap) {
 			name.split(".").reduce(function(previous, current, index, names) {
 				var expr = (previous.length > 0 ? previous : "var ") + current;
 
-				if(index < names.length-1) {
+				if(expr === "var window") {
+					imports.push("window = (window || {});");
+				} else if(index < names.length-1) {
 					imports.push(expr + " = {};");
 				} else {
 					imports.push(expr + " = " + value + ";");

--- a/package.json
+++ b/package.json
@@ -3,9 +3,16 @@
   "version": "0.6.5",
   "author": "Tobias Koppers @sokra",
   "description": "imports loader module for webpack",
+  "scripts": {
+    "test": "mocha"
+  },
   "dependencies": {
     "loader-utils": "0.2.x",
     "source-map": "0.1.x"
+  },
+  "devDependencies": {
+    "mocha": "^3.1.2",
+    "should": "^11.1.1"
   },
   "license": "MIT",
   "repository": {

--- a/test/test.js
+++ b/test/test.js
@@ -28,26 +28,4 @@ describe("loader", function() {
 			"foo.bar.baz = 2;\n\n\n"
 		);
 	});
-
-	it("should not redeclare window imports", function() {
-		loader.call({
-			query: "?window.jQuery=jquery"
-		}, "").should.be.eql(HEADER +
-			"var window = (window || {});\n" +
-			'window.jQuery = require("jquery");\n\n\n'
-		);
-	});
-
-	it("should not redeclare window for muntiple imports", function() {
-		loader.call({
-			query: "?window.jQuery=jquery,window._=lodash"
-		}, "").should.be.eql(HEADER +
-			// First import
-			"var window = (window || {});\n" +
-			'window.jQuery = require("jquery");\n' +
-			// Second import
-			"var window = (window || {});\n" +
-			'window._ = require("lodash");\n\n\n'
-		);
-	});
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,53 @@
+var should = require("should");
+var loader = require("../");
+
+var HEADER = "/*** IMPORTS FROM imports-loader ***/\n";
+
+describe("loader", function() {
+	it("should import nested objects", function() {
+		loader.call({
+			query: "?abc.def.ghi=>1"
+		}, "").should.be.eql(HEADER +
+			"var abc = {};\n" +
+			"abc.def = {};\n" +
+			"abc.def.ghi = 1;\n\n\n"
+		);
+	});
+
+	it("should import multiple nested objects", function() {
+		loader.call({
+			query: "?abc.def.ghi=>1,foo.bar.baz=>2"
+		}, "").should.be.eql(HEADER +
+			// First import
+			"var abc = {};\n" +
+			"abc.def = {};\n" +
+			"abc.def.ghi = 1;\n" +
+			// Second import
+			"var foo = {};\n" +
+			"foo.bar = {};\n" +
+			"foo.bar.baz = 2;\n\n\n"
+		);
+	});
+
+	it("should not redeclare window imports", function() {
+		loader.call({
+			query: "?window.jQuery=jquery"
+		}, "").should.be.eql(HEADER +
+			"window = (window || {});\n" +
+			'window.jQuery = require("jquery");\n\n\n'
+		);
+	});
+
+	it("should not redeclare window for muntiple imports", function() {
+		loader.call({
+			query: "?window.jQuery=jquery,window._=lodash"
+		}, "").should.be.eql(HEADER +
+			// First import
+			"window = (window || {});\n" +
+			'window.jQuery = require("jquery");\n' +
+			// Second import
+			"window = (window || {});\n" +
+			'window._ = require("lodash");\n\n\n'
+		);
+	});
+});

--- a/test/test.js
+++ b/test/test.js
@@ -8,7 +8,7 @@ describe("loader", function() {
 		loader.call({
 			query: "?abc.def.ghi=>1"
 		}, "").should.be.eql(HEADER +
-			"var abc = {};\n" +
+			"var abc = (abc || {});\n" +
 			"abc.def = {};\n" +
 			"abc.def.ghi = 1;\n\n\n"
 		);
@@ -19,11 +19,11 @@ describe("loader", function() {
 			query: "?abc.def.ghi=>1,foo.bar.baz=>2"
 		}, "").should.be.eql(HEADER +
 			// First import
-			"var abc = {};\n" +
+			"var abc = (abc || {});\n" +
 			"abc.def = {};\n" +
 			"abc.def.ghi = 1;\n" +
 			// Second import
-			"var foo = {};\n" +
+			"var foo = (foo || {});\n" +
 			"foo.bar = {};\n" +
 			"foo.bar.baz = 2;\n\n\n"
 		);
@@ -33,7 +33,7 @@ describe("loader", function() {
 		loader.call({
 			query: "?window.jQuery=jquery"
 		}, "").should.be.eql(HEADER +
-			"window = (window || {});\n" +
+			"var window = (window || {});\n" +
 			'window.jQuery = require("jquery");\n\n\n'
 		);
 	});
@@ -43,10 +43,10 @@ describe("loader", function() {
 			query: "?window.jQuery=jquery,window._=lodash"
 		}, "").should.be.eql(HEADER +
 			// First import
-			"window = (window || {});\n" +
+			"var window = (window || {});\n" +
 			'window.jQuery = require("jquery");\n' +
 			// Second import
-			"window = (window || {});\n" +
+			"var window = (window || {});\n" +
 			'window._ = require("lodash");\n\n\n'
 		);
 	});


### PR DESCRIPTION
import?abc.def.ghi=>1
=> var abc = {};
   abc.def = {};
   abc.def.ghi = 1;

import?window.jQuery=jquery
=> var window = {};
   window.jQuery = require("jquery");

Fixes #28, fixes #22, fixes #32