### PR TITLE
Allow setting dot-prop values instead of variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Query value | Equals
 ------------|-------
 `angular` | `var angular = require("angular");`
 `$=jquery` | `var $ = require("jquery");`
+`window.jQuery=jquery` | `window.jQuery = require("jquery");`
 `define=>false` | `var define = false;`
 `config=>{size:50}` | `var config = {size:50};`
 `this=>window` | `(function () { ... }).call(window);`

--- a/index.js
+++ b/index.js
@@ -26,7 +26,12 @@ module.exports = function(content, sourceMap) {
 			imports.push("(function() {");
 			postfixes.unshift("}.call(" + value + "));");
 		} else {
-			imports.push("var " + name + " = " + value + ";");
+			if (/\./.test(name)) {
+				imports.push(name + " = " + value + ";");
+			} else {
+				imports.push("var " + name + " = " + value + ";");
+			}
+
 		}
 	});
 	var prefix = HEADER + imports.join("\n") + "\n\n";


### PR DESCRIPTION
This allows to e.g. use `window` properties.

This PR contains adjustments for https://github.com/webpack/imports-loader/pull/21.